### PR TITLE
feat: 장바구니 상품 내역 조회 기능 추가

### DIFF
--- a/src/main/java/deepdive/jsonstore/domain/cart/controller/CartApiController.java
+++ b/src/main/java/deepdive/jsonstore/domain/cart/controller/CartApiController.java
@@ -1,5 +1,7 @@
 package deepdive.jsonstore.domain.cart.controller;
 
+import deepdive.jsonstore.domain.cart.dto.CartDeleteRequest;
+import deepdive.jsonstore.domain.cart.dto.CartListRequest;
 import deepdive.jsonstore.domain.cart.dto.CartRequest;
 import deepdive.jsonstore.domain.cart.dto.CartResponse;
 import deepdive.jsonstore.domain.cart.entity.Cart;
@@ -8,10 +10,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -25,5 +27,15 @@ public class CartApiController {
     public ResponseEntity<CartResponse> addProductToCart(@Valid @RequestBody CartRequest request) {
         Cart cart = cartService.addProductToCart(request.getMemberId(), request.getProductId(), request.getAmount());
         return ResponseEntity.ok(new CartResponse(cart));
+    }
+
+    // 특정 멤버 카트 상품 조회
+    @GetMapping
+    public ResponseEntity<List<CartResponse>> getCartByMemberId(@Valid CartListRequest request) {
+        List<Cart> cart = cartService.getCartByMemberId(request.getMemberId());
+        List<CartResponse> response = cart.stream()
+                .map(CartResponse::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/deepdive/jsonstore/domain/cart/dto/CartListRequest.java
+++ b/src/main/java/deepdive/jsonstore/domain/cart/dto/CartListRequest.java
@@ -1,0 +1,16 @@
+package deepdive.jsonstore.domain.cart.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartListRequest {
+    @NotNull(message = "memberId를 입력해주세요.")
+    @Positive(message = "memberId는 양수여야 합니다.")
+    private Long memberId;
+}

--- a/src/main/java/deepdive/jsonstore/domain/cart/dto/CartRequest.java
+++ b/src/main/java/deepdive/jsonstore/domain/cart/dto/CartRequest.java
@@ -16,6 +16,5 @@ public class CartRequest {
     private Long productId;
 
     @NotNull(message = "수량을 입력해주세요.")
-    @Positive(message = "수량은 0보다 커야 합니다.")
     private Long amount;
 }

--- a/src/main/java/deepdive/jsonstore/domain/cart/exception/CartErrorCode.java
+++ b/src/main/java/deepdive/jsonstore/domain/cart/exception/CartErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum CartErrorCode {
 
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+	CART_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니 내역을 찾을 수 없습니다."),
+	INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "장바구니 내역의 수량을 정상적으로 입력해주세요."),
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 	PRODUCT_FORBIDDEN(HttpStatus.FORBIDDEN, "상품에 접근할 수 없습니다."),
 	PRODUCT_OUT_OF_STOCK(HttpStatus.CONFLICT, "상품의 재고가 부족합니다.");

--- a/src/main/java/deepdive/jsonstore/domain/cart/exception/CartException.java
+++ b/src/main/java/deepdive/jsonstore/domain/cart/exception/CartException.java
@@ -27,6 +27,18 @@ public class CartException extends RuntimeException {
 		}
 	}
 
+	public static class CartNotFoundException extends CartException {
+		public CartNotFoundException() {
+			super(CartErrorCode.CART_NOT_FOUND);
+		}
+	}
+
+	public static class InvalidAmountException extends CartException {
+		public InvalidAmountException() {
+			super(CartErrorCode.INVALID_AMOUNT);
+		}
+	}
+
 	public static class MemberNotFoundException extends CartException {
 		public MemberNotFoundException() {
 			super(CartErrorCode.MEMBER_NOT_FOUND);

--- a/src/main/java/deepdive/jsonstore/domain/cart/repository/CartRepository.java
+++ b/src/main/java/deepdive/jsonstore/domain/cart/repository/CartRepository.java
@@ -3,16 +3,20 @@ package deepdive.jsonstore.domain.cart.repository;
 import deepdive.jsonstore.domain.cart.entity.Cart;
 import deepdive.jsonstore.domain.member.entity.Member;
 import deepdive.jsonstore.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
-
-    // 특정 회원의 장바구니 조회
-    Optional<Cart> findByMemberId(Long memberId);
-
+    // 멤버와 상품을 기반으로 카트 목록 조회
     Cart findByMemberAndProduct(Member member, Product product);
+
+    // 멤버ID를 기반으로 카트 목록 조회
+    @EntityGraph(attributePaths = {"product", "member"})
+    List<Cart> findByMemberId(Long memberId);
+
 }

--- a/src/main/java/deepdive/jsonstore/domain/cart/service/CartService.java
+++ b/src/main/java/deepdive/jsonstore/domain/cart/service/CartService.java
@@ -1,6 +1,5 @@
 package deepdive.jsonstore.domain.cart.service;
 
-import deepdive.jsonstore.domain.cart.dto.CartRequest;
 import deepdive.jsonstore.domain.cart.entity.Cart;
 import deepdive.jsonstore.domain.cart.exception.CartException;
 import deepdive.jsonstore.domain.cart.repository.CartRepository;
@@ -9,6 +8,8 @@ import deepdive.jsonstore.domain.product.entity.Product;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -22,10 +23,14 @@ public class CartService {
         Member member = validateService.validateMember(memberId);
         Product product = validateService.validateProduct(productId, amount);
 
+        // 이미 있는 상품을 등록하려는 경우
         Cart cart = alreadyInCart(member, product, amount);
         if (cart != null) {
             return cart;
         }
+
+        // 새 상품인데 수량이 0 이하인 경우
+        validateService.validateNewCartAmount(amount);
 
         Cart newCart = Cart.builder()
                 .member(member)
@@ -48,4 +53,14 @@ public class CartService {
         return null;
     }
 
+    // 카트 리스트 조회
+    public List<Cart> getCartByMemberId(Long memberId) {
+        // 멤버ID 기반으로 카트 리스트 조회
+        List<Cart> carts = cartRepository.findByMemberId(memberId);
+
+        // 카트 리스트가 비었는지 확인
+        validateService.validateCartList(carts);
+
+        return carts;
+    }
 }

--- a/src/main/java/deepdive/jsonstore/domain/cart/service/CartValidateService.java
+++ b/src/main/java/deepdive/jsonstore/domain/cart/service/CartValidateService.java
@@ -1,7 +1,6 @@
 package deepdive.jsonstore.domain.cart.service;
 
 import deepdive.jsonstore.domain.cart.entity.Cart;
-import deepdive.jsonstore.domain.cart.exception.CartErrorCode;
 import deepdive.jsonstore.domain.cart.exception.CartException;
 import deepdive.jsonstore.domain.cart.repository.CartRepository;
 import deepdive.jsonstore.domain.member.entity.Member;
@@ -12,6 +11,8 @@ import deepdive.jsonstore.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -47,6 +48,20 @@ public class CartValidateService {
         long sumAmount = cart.getAmount() + amount;
         if (product.getStock() < sumAmount)
             throw new CartException.ProductOutOfStockException();
+        if (sumAmount < 1 || amount == 0)
+            throw new CartException.InvalidAmountException();
         return sumAmount;
+    }
+
+    public void validateNewCartAmount(Long amount) {
+        if (amount < 1) {
+            throw new CartException.InvalidAmountException();
+        }
+    }
+
+    public void validateCartList(List<Cart> carts) {
+        if (carts.isEmpty()) {
+            throw new CartException.CartNotFoundException();
+        }
     }
 }

--- a/src/test/java/deepdive/jsonstore/domain/cart/controller/CartApiControllerTest.java
+++ b/src/test/java/deepdive/jsonstore/domain/cart/controller/CartApiControllerTest.java
@@ -23,9 +23,12 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.List;
+
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(SpringExtension.class)
@@ -89,6 +92,44 @@ class CartApiControllerTest {
             mockMvc.perform(post("/api/v1/carts")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(invalidJson))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("getCartByMemberId API 테스트")
+    class GetCartByMemberId {
+
+        @Test
+        @DisplayName("성공 - 장바구니 목록 조회")
+        void success() throws Exception {
+            // given
+            Cart cart = Cart.builder()
+                    .id(1L)
+                    .member(Member.builder().id(1L).build())
+                    .product(Product.builder().id(10L).build())
+                    .amount(2L)
+                    .build();
+
+            Mockito.when(cartService.getCartByMemberId(anyLong()))
+                    .thenReturn(List.of(cart));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/carts")
+                            .param("memberId", "1")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(1)))
+                    .andExpect(jsonPath("$[0].id").value(1L))
+                    .andExpect(jsonPath("$[0].amount").value(2));
+        }
+
+        @Test
+        @DisplayName("실패 - 유효하지 않은 요청 (memberId 누락)")
+        void fail_invalidRequest() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/v1/carts")
+                            .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest());
         }
     }

--- a/src/test/java/deepdive/jsonstore/domain/cart/service/CartServiceTest.java
+++ b/src/test/java/deepdive/jsonstore/domain/cart/service/CartServiceTest.java
@@ -10,8 +10,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class CartServiceTest {
@@ -132,6 +133,46 @@ class CartServiceTest {
             // then
             assertThat(result).isNull();
             verify(cartRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("getCartByMemberId 메서드")
+    class GetCartByMemberId {
+
+        @Test
+        @DisplayName("성공 - 유효한 memberId로 카트 목록 조회")
+        void success() {
+            // given
+            Long memberId = 1L;
+
+            List<Cart> mockCarts = List.of(
+                    Cart.builder()
+                            .id(1L)
+                            .member(Member.builder().id(memberId).build())
+                            .product(Product.builder().id(10L).build())
+                            .amount(2L)
+                            .build(),
+                    Cart.builder()
+                            .id(2L)
+                            .member(Member.builder().id(memberId).build())
+                            .product(Product.builder().id(20L).build())
+                            .amount(1L)
+                            .build()
+            );
+
+            when(cartRepository.findByMemberId(memberId)).thenReturn(mockCarts);
+
+            // when
+            List<Cart> result = cartService.getCartByMemberId(memberId);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getId()).isEqualTo(1L);
+            assertThat(result.get(1).getProduct().getId()).isEqualTo(20L);
+
+            verify(cartRepository).findByMemberId(memberId);
+            verify(validateService).validateCartList(mockCarts);
         }
     }
 }

--- a/src/test/java/deepdive/jsonstore/domain/cart/service/CartValidateServiceTest.java
+++ b/src/test/java/deepdive/jsonstore/domain/cart/service/CartValidateServiceTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -157,6 +159,39 @@ class CartValidateServiceTest {
 
             assertThrows(CartException.ProductOutOfStockException.class,
                     () -> cartValidateService.validateAmount(cart, product, addAmount));
+        }
+    }
+
+    @Nested
+    @DisplayName("validateCart 메서드")
+    class ValidateCart {
+
+        @Test
+        @DisplayName("성공 - 카트 목록이 존재하면 예외를 던지지 않는다")
+        void success() {
+            // given
+            List<Cart> carts = List.of(
+                    Cart.builder()
+                            .id(1L)
+                            .member(Member.builder().id(1L).build())
+                            .product(Product.builder().id(10L).build())
+                            .amount(2L)
+                            .build()
+            );
+
+            // when & then
+            assertDoesNotThrow(() -> cartValidateService.validateCartList(carts));
+        }
+
+        @Test
+        @DisplayName("실패 - 카트 목록이 비어있으면 CartNotFoundException 예외 발생")
+        void fail_emptyCartList() {
+            // given
+            List<Cart> emptyCarts = List.of();
+
+            // when & then
+            assertThatThrownBy(() -> cartValidateService.validateCartList(emptyCarts))
+                    .isInstanceOf(CartException.CartNotFoundException.class);
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #32

## 📝 작업 내용
> 멤버별 장바구니 상품 목록 조회 기능 추가
> 장바구니 상품 감소 로직 추가
> 장바구니 상품 목록 조회 테스트코드 추가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/35a2cb9d-f4cf-4e19-aa5b-35da9645e744)
![image](https://github.com/user-attachments/assets/db18dd76-b38c-4da9-9cc8-a1e396a6bb80)

## 💬 리뷰 요구사항(선택)
