### PR TITLE
refactor: 피드백 사항 적용, 주소 인증하는 기능 분리

### DIFF
--- a/src/main/java/deepdive/jsonstore/common/exception/MemberException.java
+++ b/src/main/java/deepdive/jsonstore/common/exception/MemberException.java
@@ -23,5 +23,11 @@ public class MemberException extends RuntimeException {
         }
     }
 
+    public static class MemberNotFound extends MemberException {
+        public MemberNotFound() {
+            super(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
 
 }

--- a/src/main/java/deepdive/jsonstore/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/deepdive/jsonstore/domain/delivery/controller/DeliveryController.java
@@ -17,41 +17,37 @@ public class DeliveryController {
     private final DeliveryService deliveryService;
 
     @PostMapping("/delivery")
-    public ResponseEntity<?> createDelivery(String email, @RequestBody DeliveryRegRequestDTO deliveryRegDTO) { //인증 모듈 추가 시 수정 필요
-        deliveryService.createDelivery(email, deliveryRegDTO);
+    public ResponseEntity<?> createDelivery(UUID memberUid, @RequestBody DeliveryRegRequestDTO deliveryRegDTO) { //인증 모듈 추가 시 수정 필요
+        deliveryService.createDelivery(memberUid, deliveryRegDTO);
 
         return ResponseEntity.created(URI.create("/api/v1/delivery")).build(); //HTTP method는 어떻게 전달하지?
-
     }
 
     @DeleteMapping("/delivery/{uid}")
-    public ResponseEntity<?> deleteDelivery(String email, @PathVariable UUID uid){
-        deliveryService.deleteDelivery(email, uid);
+    public ResponseEntity<?> deleteDelivery(UUID memberUid, @PathVariable UUID uid){
+        deliveryService.deleteDelivery(memberUid, uid);
 
         return ResponseEntity.ok().build();
-
     }
 
     @GetMapping("/delivery")
-    public ResponseEntity<?> getDelivery(String email){
+    public ResponseEntity<?> getDelivery(UUID memberUid){
 
-        return ResponseEntity.ok(deliveryService.getDelivery(email));
+        return ResponseEntity.ok(deliveryService.getDelivery(memberUid));
   }
   
     @PutMapping("/delivery/{uid}")
-    public ResponseEntity<?> updateDelivery(String email, @RequestBody DeliveryRegRequestDTO deliveryRegDTO, @PathVariable UUID uid){
-        deliveryService.updateDelivery(email, uid, deliveryRegDTO);
+    public ResponseEntity<?> updateDelivery(UUID memberUid, @RequestBody DeliveryRegRequestDTO deliveryRegDTO, @PathVariable UUID uid){
+        deliveryService.updateDelivery(memberUid, uid, deliveryRegDTO);
 
         return ResponseEntity.ok(URI.create("/api/v1/delivery"));
-
     }
 
     @PatchMapping("/delivery/default/{uid}")
-    public ResponseEntity<?> setDefaultDelivery(String email, @PathVariable UUID uid){
+    public ResponseEntity<?> setDefaultDelivery(UUID memberUid, @PathVariable UUID uid){
 
-        deliveryService.setDeliveryDefault(email, uid);
+        deliveryService.setDeliveryDefault(memberUid, uid);
 
         return ResponseEntity.noContent().build();
-
     }
 }

--- a/src/main/java/deepdive/jsonstore/domain/delivery/entity/Delivery.java
+++ b/src/main/java/deepdive/jsonstore/domain/delivery/entity/Delivery.java
@@ -1,6 +1,7 @@
 package deepdive.jsonstore.domain.delivery.entity;
 
 import deepdive.jsonstore.common.entity.BaseEntity;
+import deepdive.jsonstore.domain.delivery.dto.DeliveryRegRequestDTO;
 import deepdive.jsonstore.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -44,5 +45,11 @@ public class Delivery extends BaseEntity {
     )
     private Member member;
 
+    public void updateDelivery(DeliveryRegRequestDTO dto) {
+        this.address = dto.address();
+        this.zipCode = dto.zipCode();
+        this.phone = dto.phone();
+        this.recipient = dto.recipient();
+    }
 
 }

--- a/src/main/java/deepdive/jsonstore/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/deepdive/jsonstore/domain/delivery/repository/DeliveryRepository.java
@@ -16,8 +16,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
     @Query("SELECT new deepdive.jsonstore.domain.delivery.dto.DeliveryResponseDTO(d.address, d.zipCode, d.phone, d.recipient) " +
             "FROM Delivery d " +
-            "WHERE d.member.email = :email")
-    List<DeliveryResponseDTO> findByMemberEmailAsDTO(@Param("email") String email);
+            "WHERE d.member.uid = :uid")
+    List<DeliveryResponseDTO> findByMemberUidAsDTO(@Param("uid") UUID uid);
 
     boolean existsByUid(UUID uid);
 }

--- a/src/main/java/deepdive/jsonstore/domain/delivery/service/DeliveryAddressValidationService.java
+++ b/src/main/java/deepdive/jsonstore/domain/delivery/service/DeliveryAddressValidationService.java
@@ -1,0 +1,61 @@
+package deepdive.jsonstore.domain.delivery.service;
+
+import deepdive.jsonstore.domain.delivery.exception.DeliveryException;
+import deepdive.jsonstore.domain.delivery.repository.DeliveryRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Service
+public class DeliveryAddressValidationService {
+    private final RestTemplate restTemplate;
+
+    private static final String BASE_URL = "https://www.juso.go.kr/addrlink/addrLinkApi.do";
+    private final DeliveryRepository deliveryRepository;
+
+    public DeliveryAddressValidationService(RestTemplateBuilder builder, DeliveryRepository deliveryRepository) {
+        this.restTemplate = builder.build(); // 테스트에서 주입 가능
+        this.deliveryRepository = deliveryRepository;
+    }
+
+    @Value("${external.api.address.key:dummy-key}")
+    private String ADDRESS_API_KEY;
+
+    public void validateZipCode(String zipcode) {
+        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
+                .queryParam("currentPage", 1)
+                .queryParam("countPerPage", 1)
+                .queryParam("keyword", zipcode)
+                .queryParam("confmKey", ADDRESS_API_KEY)
+                .queryParam("resultType", "json")
+                .toUriString();
+
+        String response = restTemplate.getForObject(url, String.class);
+
+        JSONObject json = new JSONObject(response);
+
+        JSONObject results = json.getJSONObject("results");
+        JSONObject common = results.getJSONObject("common");
+        String errorCode = common.getString("errorCode");
+        String errorMessage = common.getString("errorMessage");
+
+        //api key 또는 api 서버 문제
+        if ("E0001".equals(errorCode) || "-999".equals(errorCode)) {
+            log.warn("Address API returned error. code={}, message={}", errorCode, errorMessage);
+            throw new DeliveryException.AddressAPIException();
+        }
+
+        JSONArray address = results.getJSONArray("juso");
+
+        if (address.length() <= 0){
+            throw new DeliveryException.AddressNotFoundException();
+        }
+
+    }
+}

--- a/src/main/java/deepdive/jsonstore/domain/delivery/service/DeliveryService.java
+++ b/src/main/java/deepdive/jsonstore/domain/delivery/service/DeliveryService.java
@@ -3,11 +3,10 @@ package deepdive.jsonstore.domain.delivery.service;
 import deepdive.jsonstore.domain.delivery.dto.DeliveryRegRequestDTO;
 import deepdive.jsonstore.domain.delivery.dto.DeliveryResponseDTO;
 import deepdive.jsonstore.domain.delivery.entity.Delivery;
-import deepdive.jsonstore.domain.delivery.exception.DeliveryException;
 import deepdive.jsonstore.domain.delivery.repository.DeliveryRepository;
 import deepdive.jsonstore.domain.member.entity.Member;
-import deepdive.jsonstore.domain.member.repository.MemberRepository;
-import jakarta.persistence.EntityNotFoundException;
+import deepdive.jsonstore.domain.member.service.MemberValidationService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,75 +20,66 @@ import java.util.UUID;
 public class DeliveryService{
 
     private final DeliveryRepository deliveryRepository;
-    private final MemberRepository memberRepository; // import 추가
+    private final MemberValidationService memberValidationService;
     private final DeliveryValidationService deliveryValidationService;
+    private final DeliveryAddressValidationService deliveryAddressValidationService;
 
-
-    public void createDelivery(String email, DeliveryRegRequestDTO dto) {
-        Member member = memberRepository.findByEmail(email).orElseThrow(EntityNotFoundException::new);
-
+    //배송지 등록
+    public void createDelivery(UUID memberUid, DeliveryRegRequestDTO dto) {
+        Member member = memberValidationService.findByUid(memberUid);
         Delivery delivery = dto.toDelivery(member);
 
-        if (!deliveryValidationService.validateZipCode(dto.zipCode())) {
-            throw new DeliveryException.AddressNotFoundException();
-        }
+        //우편번호 유효성 검사
+        deliveryAddressValidationService.validateZipCode(dto.zipCode());
 
         deliveryRepository.save(delivery);
 
     }
 
-    public void deleteDelivery(String email, UUID uid) {
-        Delivery delivery = deliveryRepository.findByUid(uid).orElseThrow(DeliveryException.DeliveryNotFoundException::new);
+    //배송지 삭제
+    public void deleteDelivery(UUID memberUid, UUID deliveryUid) {
+        Delivery delivery = deliveryValidationService.getDeliveryByUid(deliveryUid);
 
-        if (!delivery.getMember().getEmail().equals(email)) {
-            throw new DeliveryException.DeliveryAccessDeniedException();
-        }
+        //배송지 접근 권한 검사
+        deliveryValidationService.validateMember(delivery,memberUid);
 
         deliveryRepository.delete(delivery);
     }
 
-    public List<DeliveryResponseDTO> getDelivery(String email) {
+    //배송지 조회
+    public List<DeliveryResponseDTO> getDelivery(UUID memberUid) {
 
-        if (!memberRepository.existsByEmail(email)) {
-            throw new DeliveryException.DeliveryAccessDeniedException();
-        }
+        memberValidationService.existsByUid(memberUid);
 
-        return deliveryRepository.findByMemberEmailAsDTO(email);
+        return deliveryRepository.findByMemberUidAsDTO(memberUid);
 
     }
 
+    //배송지 수정
+    @Transactional
+    public void updateDelivery(UUID memberUid, UUID deliveryUid, DeliveryRegRequestDTO dto) {
+        Delivery delivery = deliveryValidationService.getDeliveryByUid(deliveryUid);
 
-    public void updateDelivery(String email, UUID uid, DeliveryRegRequestDTO dto) {
-        Delivery delivery = deliveryRepository.findByUid(uid).orElseThrow(DeliveryException.DeliveryNotFoundException::new);
-
-        if (!delivery.getMember().getEmail().equals(email)) {
-            throw new DeliveryException.DeliveryAccessDeniedException();
-        }
+        //배송지 접근 권한 검사
+        deliveryValidationService.validateMember(delivery,memberUid);
 
         //우편번호 유효성 검사
-        if (!deliveryValidationService.validateZipCode(dto.zipCode())) {
-            throw new DeliveryException.AddressNotFoundException();
-        }
+        deliveryAddressValidationService.validateZipCode(dto.zipCode());
 
-        delivery.setAddress(dto.address());
-        delivery.setZipCode(dto.zipCode());
-        delivery.setPhone(dto.phone());
-        delivery.setRecipient(dto.recipient());
-        deliveryRepository.save(delivery);
+        delivery.updateDelivery(dto);
 
     }
 
-    public void setDeliveryDefault(String email, UUID uid) {
-        Delivery delivery = deliveryRepository.findByUid(uid).orElseThrow(EntityNotFoundException::new);
+    //기본 배송지 설정
+    @Transactional
+    public void setDeliveryDefault(UUID memberUid, UUID deliveryUid) {
+        Delivery delivery = deliveryValidationService.getDeliveryByUid(deliveryUid);
 
-        if (!delivery.getMember().getEmail().equals(email)) {
-            throw new DeliveryException.DeliveryAccessDeniedException();
-        }
+        //배송지 접근 권한 검사
+        deliveryValidationService.validateMember(delivery,memberUid);
 
-        Member member = memberRepository.findByEmail(email).orElseThrow(EntityNotFoundException::new);
+        Member member = memberValidationService.findByUid(memberUid);
 
         member.setDefaultDelivery(delivery);
-        memberRepository.save(member);
-
     }
 }

--- a/src/main/java/deepdive/jsonstore/domain/delivery/service/DeliveryValidationService.java
+++ b/src/main/java/deepdive/jsonstore/domain/delivery/service/DeliveryValidationService.java
@@ -17,8 +17,8 @@ public class DeliveryValidationService {
     private final DeliveryRepository deliveryRepository;
 
     public Delivery getDeliveryByUid(UUID uid) {
-        Delivery delivery = deliveryRepository.findByUid(uid).orElseThrow(DeliveryException.DeliveryNotFoundException::new);
-        return delivery;
+        return deliveryRepository.findByUid(uid).orElseThrow(DeliveryException.DeliveryNotFoundException::new);
+         
     }
 
     public void validateMember(Delivery delivery, UUID memberUid) {

--- a/src/main/java/deepdive/jsonstore/domain/delivery/service/DeliveryValidationService.java
+++ b/src/main/java/deepdive/jsonstore/domain/delivery/service/DeliveryValidationService.java
@@ -1,58 +1,30 @@
 package deepdive.jsonstore.domain.delivery.service;
 
+import deepdive.jsonstore.domain.delivery.entity.Delivery;
 import deepdive.jsonstore.domain.delivery.exception.DeliveryException;
+import deepdive.jsonstore.domain.delivery.repository.DeliveryRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class DeliveryValidationService {
 
-    private final RestTemplate restTemplate;
+    private final DeliveryRepository deliveryRepository;
 
-    private static final String BASE_URL = "https://www.juso.go.kr/addrlink/addrLinkApi.do";
-
-    public DeliveryValidationService(RestTemplateBuilder builder) {
-        this.restTemplate = builder.build(); // 테스트에서 주입 가능
+    public Delivery getDeliveryByUid(UUID uid) {
+        Delivery delivery = deliveryRepository.findByUid(uid).orElseThrow(DeliveryException.DeliveryNotFoundException::new);
+        return delivery;
     }
 
-    @Value("${external.api.address.key:dummy-key}")
-    private String ADDRESS_API_KEY;
-
-    public boolean validateZipCode(String zipcode) {
-        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
-                .queryParam("currentPage", 1)
-                .queryParam("countPerPage", 1)
-                .queryParam("keyword", zipcode)
-                .queryParam("confmKey", ADDRESS_API_KEY)
-                .queryParam("resultType", "json")
-                .toUriString();
-
-        String response = restTemplate.getForObject(url, String.class);
-
-        JSONObject json = new JSONObject(response);
-
-        JSONObject results = json.getJSONObject("results");
-        JSONObject common = results.getJSONObject("common");
-        String errorCode = common.getString("errorCode");
-        String errorMessage = common.getString("errorMessage");
-
-        //api key 또는 api 서버 문제
-        if ("E0001".equals(errorCode) || "-999".equals(errorCode)) {
-            log.warn("Address API returned error. code={}, message={}", errorCode, errorMessage);
-            throw new DeliveryException.AddressAPIException();
+    public void validateMember(Delivery delivery, UUID memberUid) {
+        if (!delivery.getMember().getUid().equals(memberUid)) {
+            throw new DeliveryException.DeliveryAccessDeniedException();
         }
-
-        JSONArray address = results.getJSONArray("juso");
-
-        return address.length() > 0;
-
     }
 
 }

--- a/src/main/java/deepdive/jsonstore/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/deepdive/jsonstore/domain/member/exception/MemberErrorCode.java
@@ -12,7 +12,9 @@ public enum MemberErrorCode {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
     ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 탈퇴된 회원입니다."),
-    DELETE_CONFLICT(HttpStatus.CONFLICT, "회원 탈퇴 중 문제가 발생했습니다.");
+    DELETE_CONFLICT(HttpStatus.CONFLICT, "회원 탈퇴 중 문제가 발생했습니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST,"찾을 수 없는 회원입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/deepdive/jsonstore/domain/member/repository/MemberRepository.java
+++ b/src/main/java/deepdive/jsonstore/domain/member/repository/MemberRepository.java
@@ -19,6 +19,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByUid(UUID uid);
+
     Optional<Member> findByEmailAndIsDeletedFalse(String email);
 
     Optional<Member> findByUid(UUID uid);
@@ -29,6 +31,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Transactional
     @Query("DELETE FROM Member m WHERE m.isDeleted = true AND m.deletedAt <= :cutoffDate")
     void deleteAllSoftDeletedBefore(@Param("cutoffDate") LocalDateTime cutoffDate);
-
 
 }

--- a/src/main/java/deepdive/jsonstore/domain/member/service/MemberValidationService.java
+++ b/src/main/java/deepdive/jsonstore/domain/member/service/MemberValidationService.java
@@ -1,6 +1,7 @@
 package deepdive.jsonstore.domain.member.service;
 
 import deepdive.jsonstore.common.exception.CommonException;
+import deepdive.jsonstore.common.exception.MemberException;
 import deepdive.jsonstore.domain.member.entity.Member;
 import deepdive.jsonstore.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +23,11 @@ public class MemberValidationService {
     public Member findById(Long id) {
         //TODO : 커스텀에러로 변경할 것
         return memberRepository.findById(id).orElseThrow(CommonException.InternalServerException::new);
+    }
+
+    public void existsByUid(UUID uid) {
+        if (!memberRepository.existsByUid(uid)){
+            throw new MemberException.MemberNotFound();
+        }
     }
 }

--- a/src/test/java/deepdive/jsonstore/domain/delivery/service/DeliveryAddressValidationServiceTest.java
+++ b/src/test/java/deepdive/jsonstore/domain/delivery/service/DeliveryAddressValidationServiceTest.java
@@ -19,8 +19,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.client.RestTemplate;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -29,8 +30,8 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @Transactional
 @Rollback
-@DisplayName("DeliveryValidationService 테스트")
-class DeliveryValidationServiceTest {
+@DisplayName("deliveryAddressValidationService 테스트")
+class DeliveryAddressValidationServiceTest {
 
     @MockitoBean
     private FirebaseConfig firebaseConfig;
@@ -51,7 +52,7 @@ class DeliveryValidationServiceTest {
     private RestTemplateBuilder restTemplateBuilder;
 
     @Autowired
-    private DeliveryValidationService deliveryValidationService;
+    private DeliveryAddressValidationService deliveryAddressValidationService;
 
     @TestConfiguration
     static class TestConfig {
@@ -101,11 +102,8 @@ class DeliveryValidationServiceTest {
 
             when(restTemplate.getForObject(anyString(),eq(String.class))).thenReturn(mockResponse);
 
-            //when
-            boolean result = deliveryValidationService.validateZipCode(zipCode);
-
-            //then
-            assertThat(result).isTrue();
+            //when & then
+            assertDoesNotThrow(() -> deliveryAddressValidationService.validateZipCode(zipCode));
 
         }
 
@@ -129,7 +127,7 @@ class DeliveryValidationServiceTest {
             when(restTemplate.getForObject(anyString(), eq(String.class))).thenReturn(errorResponse);
 
             // then
-            assertThatThrownBy(() -> deliveryValidationService.validateZipCode(zipCode))
+            assertThatThrownBy(() -> deliveryAddressValidationService.validateZipCode(zipCode))
                     .isInstanceOf(DeliveryException.AddressAPIException.class);
         }
         @Test
@@ -150,11 +148,10 @@ class DeliveryValidationServiceTest {
         """;
             when(restTemplate.getForObject(anyString(),eq(String.class))).thenReturn(errorResponse);
 
-            //when
-            boolean result = deliveryValidationService.validateZipCode(zipCode);
+            //when & then
+            assertThrows(DeliveryException.AddressNotFoundException.class,
+                    () -> deliveryAddressValidationService.validateZipCode("12345"));
 
-            //then
-            assertThat(result).isFalse();
         }
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> [#109 ](https://github.com/json-store-25/json-store-be/issues/109)

## 📝 작업 내용

> 피드백 내용 적용하였습니다.
   기존에 api를 이용하여 주소를 인증하던 기능은 따로 분리하였습니다.
